### PR TITLE
bug fix - bundle exec worked only for the first element in files

### DIFF
--- a/tasks/haml.js
+++ b/tasks/haml.js
@@ -18,11 +18,11 @@ module.exports = function(grunt) {
 
     grunt.verbose.writeflags(options, 'Options');
 
+    var bundleExec = options.bundleExec;
+    delete options.bundleExec;
+
     grunt.util.async.forEachSeries(this.files, function(f, next) {
       var args;
-      var bundleExec = options.bundleExec;
-
-      delete options.bundleExec;
 
       args = [f.dest, '--stdin'].concat(helpers.optsToArgs(options));
 


### PR DESCRIPTION
Before this fix, bundleExec was read and removed from the options object in every loop cycle, which caused it to work only in the first cycle (in the second cycle it was already removed from the object). This simple fix reads and removes bundleExec right before the loop starts instead.
